### PR TITLE
#159133572 Solve Bug on Serving static files and reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Its build using the following modules
 - [Express winston](https://www.npmjs.com/package/express-winston)
 - [Minimist](https://www.npmjs.com/package/minimist)
 - [Command line Usage](https://www.npmjs.com/package/command-line-usage)
+- [Path](https://www.npmjs.com/package/path)
 
 ## Commands
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 const Middlewares = require('../lib/middlewares');
 const compression = require('compression');
+const path = require('path');
 
 class Server {
   constructor(options) {
@@ -25,10 +26,14 @@ class Server {
     // Use winston access logger for all access logs
     this.instance.use(middlewares.accessLogger());
     // Setup public directory where all the files will be served from
-    this.instance.use('/*', this.express.static(this.options.public));
+    this.instance.use(this.express.static(this.options.public));
     // Use winston error logger for all error logs
     // Causes error on install
     // this.instance.use(middlewares.errorLogger());
+    // Ensure each request is directed to the index.html file
+    this.instance.get('*', (req, res) => {
+      res.sendFile(path.resolve('index.html'));
+    });
 
     return this.instance;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "servir",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -162,17 +162,6 @@
         "on-headers": "~1.0.1",
         "safe-buffer": "5.1.1",
         "vary": "~1.1.2"
-      }
-    },
-    "connect": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
-      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-      "requires": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
-        "utils-merge": "1.0.1"
       }
     },
     "content-disposition": {
@@ -378,20 +367,6 @@
         "moment": "^2.11.2"
       }
     },
-    "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -573,10 +548,24 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -787,6 +776,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servir",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "bin/serve",
   "preferGlobal": true,
   "bin": {
@@ -18,6 +18,7 @@
     "express": "^4.16.3",
     "express-winston": "^2.5.1",
     "minimist": "^1.2.0",
+    "path": "^0.12.7",
     "winston": "^3.0.0",
     "winston-daily-rotate-file": "^3.2.3"
   }


### PR DESCRIPTION
#### What does this PR do?
This P.R. fixes a bug where static files were not being served properly, as well as  another bug where reloading the application on the browser was raising an error.

#### Description of Task to be completed?
The task involved finding a way to ensure reloading of the application on the browser will direct requests to the index.html file. It also ensured static files were found and rendered properly while in the public folder.

#### How should this be manually tested?
Clone this repository minding that the P.R. is generated from a fork and the changes are in a specific branch.
```
git clone -b bg-reloading-and-serving-static-files-159133572 https://github.com/WinstonKamau/servir.git
```
Change directory into the repository
```
cd servir
```
Add serve locally to your machine by running the command below
```
npm link
```
Once this is done visit your front end application repository and perform operations to build it for production.
e.g. 
```
yarn install
yarn build
```
Change directory into the folder for production depending on your applicaiton
e.g `cd public` or `cd build` or cd `dist`
Start the application
```
serve
``` 
#### What are the relevant pivotal tracker stories?
[159133572](https://www.pivotaltracker.com/story/show/159133572)
#### Any background context you want to add?
NO

#### Screenshots