### PR TITLE
#159192150 Fix 502 internal server error

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -100,7 +100,7 @@ class Middlewares {
     return (req, res, next) => {
       if (!this.secure) return next();
       if (req.headers["x-forwarded-proto"] == "https") return next();
-      return res.redirect(status, `https://${req.hostname + req.originalUrl}`);
+      return res.redirect(status, `https://${req.get('host') + req.originalUrl}`);
     };
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Fix the issue of the server failing in staging environments when used with the https redirect option. This is accomplished

#### Description of Task to be completed?
When Servir@1.0.3 is used in frontend application it fails with a 502. Identify the source of the bug and fix it.

#### How should this be manually tested?
Clone the fork using `git clone --single-branch -b bg-fix-internal-server-error-159192150 https://github.com/AnthonyGW/servir.git`.
Remove previous installations of servir and link to the cloned repo with `npm link`.
Use the `serve -s true` command when serving static files and http URLs to ensure that the server redirects to the same hostname and port.

#### Any background context you want to add?
On investigation, it seems that this error only occurs when using the https redirect option when starting the server remotely. We narrowed down the possibility to a non-uniform hostname/port in the `forcehttpsredirect()` method in the Middlewares class while testing locally.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/159192150